### PR TITLE
更新 Bitwarden_rs 

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM bitwardenrs/server:latest
+FROM vaultwarden/server:latest
 
 # 使用 mariadb-client 代替 mysql-client
 # debian 下安装 mysql-client 较困难
@@ -11,4 +11,3 @@ RUN chmod +x ./entrypoint.sh
 ENTRYPOINT [ "./entrypoint.sh" ]
 
 CMD ["/start.sh"]
-

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Bitwarden 是一款自由且开源的密码管理服务，用户可在加密的�
 
 - SIGNUPS_ALLOWED： 是否允许注册
 
-更多配置参考：https://github.com/dani-garcia/bitwarden_rs/wiki
+更多配置参考：https://github.com/dani-garcia/vaultwarden/wiki
 
 ### 依赖
 


### PR DESCRIPTION
Bitwarden_RS 原仓库已重命名
----

为了区分品牌辨识度，原开发者对 Bitwarden_RS 仓库进行了重命名。
更新至新仓库可以尽可能的避免部署失败的现象。

----
更新内容：
- 更新了 Dockerfile 中的镜像名
- 更新 Readme.md
----
公告原文：
📢 The project which was known as Bitwarden_RS and has been renamed to separate itself from the official Bitwarden server in the hopes of avoiding confusion and trademark/branding issues. Please see [#1642](https://github.com/dani-garcia/vaultwarden/discussions/1642) for more explanation.